### PR TITLE
chore: update package names

### DIFF
--- a/packages/capacitor-plugin/android/build.gradle
+++ b/packages/capacitor-plugin/android/build.gradle
@@ -22,7 +22,7 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
-    namespace "com.outsystems.capacitor.plugins.geolocation"
+    namespace "com.capacitorjs.plugins.geolocation"
     compileSdk project.hasProperty('compileSdkVersion') ? rootProject.ext.compileSdkVersion : 35
     defaultConfig {
         minSdkVersion project.hasProperty('minSdkVersion') ? rootProject.ext.minSdkVersion : 23

--- a/packages/capacitor-plugin/android/src/androidTest/java/com/capacitorjs/plugins/geolocation/ExampleInstrumentedTest.java
+++ b/packages/capacitor-plugin/android/src/androidTest/java/com/capacitorjs/plugins/geolocation/ExampleInstrumentedTest.java
@@ -1,4 +1,4 @@
-package com.getcapacitor.myapp;
+package com.capacitorjs.plugins.geolocation;
 
 import static org.junit.Assert.*;
 
@@ -21,6 +21,6 @@ public class ExampleInstrumentedTest {
         // Context of the app under test.
         Context appContext = InstrumentationRegistry.getInstrumentation().getTargetContext();
 
-        assertEquals("com.getcapacitor.app", appContext.getPackageName());
+        assertEquals("com.capacitorjs.plugins.geolocation", appContext.getPackageName());
     }
 }

--- a/packages/capacitor-plugin/android/src/main/kotlin/com/capacitorjs/plugins/geolocation/GeolocationErrors.kt
+++ b/packages/capacitor-plugin/android/src/main/kotlin/com/capacitorjs/plugins/geolocation/GeolocationErrors.kt
@@ -1,4 +1,4 @@
-package com.outsystems.capacitor.plugins.geolocation
+package com.capacitorjs.plugins.geolocation
 
 /**
  * Object with plugin errors

--- a/packages/capacitor-plugin/android/src/main/kotlin/com/capacitorjs/plugins/geolocation/GeolocationPlugin.kt
+++ b/packages/capacitor-plugin/android/src/main/kotlin/com/capacitorjs/plugins/geolocation/GeolocationPlugin.kt
@@ -1,4 +1,4 @@
-package com.outsystems.capacitor.plugins.geolocation
+package com.capacitorjs.plugins.geolocation
 
 import android.Manifest
 import android.os.Build
@@ -12,10 +12,10 @@ import com.getcapacitor.annotation.CapacitorPlugin
 import com.getcapacitor.annotation.Permission
 import com.getcapacitor.annotation.PermissionCallback
 import com.google.android.gms.location.LocationServices
-import com.outsystems.plugins.osgeolocation.controller.OSGLOCController
-import com.outsystems.plugins.osgeolocation.model.OSGLOCException
-import com.outsystems.plugins.osgeolocation.model.OSGLOCLocationOptions
-import com.outsystems.plugins.osgeolocation.model.OSGLOCLocationResult
+import io.ionic.libs.osgeolocationlib.controller.OSGLOCController
+import io.ionic.libs.osgeolocationlib.model.OSGLOCException
+import io.ionic.libs.osgeolocationlib.model.OSGLOCLocationOptions
+import io.ionic.libs.osgeolocationlib.model.OSGLOCLocationResult
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.cancel

--- a/packages/capacitor-plugin/android/src/test/java/com/capacitorjs/plugins/geolocation/ExampleUnitTest.java
+++ b/packages/capacitor-plugin/android/src/test/java/com/capacitorjs/plugins/geolocation/ExampleUnitTest.java
@@ -1,4 +1,4 @@
-package com.getcapacitor.myapp;
+package com.capacitorjs.plugins.geolocation;
 
 import static org.junit.Assert.*;
 

--- a/packages/example-app-capacitor/android/app/build.gradle
+++ b/packages/example-app-capacitor/android/app/build.gradle
@@ -1,10 +1,10 @@
 apply plugin: 'com.android.application'
 
 android {
-    namespace "com.outsystems.exampleucapp.capacitor.plugins.geolocation"
+    namespace "com.capacitorjs.exampleucapp.plugins.geolocation"
     compileSdk rootProject.ext.compileSdkVersion
     defaultConfig {
-        applicationId "com.outsystems.exampleucapp.capacitor.plugins.geolocation"
+        applicationId "com.capacitorjs.exampleucapp.plugins.geolocation"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
         versionCode 1

--- a/packages/example-app-capacitor/android/app/src/androidTest/java/com/capacitorjs/exampleucapp/plugins/geolocation/ExampleInstrumentedTest.java
+++ b/packages/example-app-capacitor/android/app/src/androidTest/java/com/capacitorjs/exampleucapp/plugins/geolocation/ExampleInstrumentedTest.java
@@ -1,4 +1,4 @@
-package com.getcapacitor.android;
+package com.capacitorjs.exampleucapp.plugins.geolocation;
 
 import static org.junit.Assert.*;
 
@@ -21,6 +21,6 @@ public class ExampleInstrumentedTest {
         // Context of the app under test.
         Context appContext = InstrumentationRegistry.getInstrumentation().getTargetContext();
 
-        assertEquals("com.getcapacitor.android", appContext.getPackageName());
+        assertEquals("com.capacitorjs.exampleucapp.plugins.geolocation", appContext.getPackageName());
     }
 }

--- a/packages/example-app-capacitor/android/app/src/main/java/com/capacitorjs/exampleucapp/plugins/geolocation/MainActivity.java
+++ b/packages/example-app-capacitor/android/app/src/main/java/com/capacitorjs/exampleucapp/plugins/geolocation/MainActivity.java
@@ -1,4 +1,4 @@
-package com.outsystems.exampleucapp.capacitor.plugins.geolocation;
+package com.capacitorjs.exampleucapp.plugins.geolocation;
 
 import com.getcapacitor.BridgeActivity;
 

--- a/packages/example-app-capacitor/android/app/src/main/res/values/strings.xml
+++ b/packages/example-app-capacitor/android/app/src/main/res/values/strings.xml
@@ -2,6 +2,6 @@
 <resources>
     <string name="app_name">OSGLOC Sample</string>
     <string name="title_activity_main">OSGLOC Sample</string>
-    <string name="package_name">com.outsystems.exampleucapp.capacitor.plugins.geolocation</string>
-    <string name="custom_url_scheme">com.outsystems.exampleucapp.capacitor.plugins.geolocation</string>
+    <string name="package_name">com.capacitorjs.exampleucapp.plugins.geolocation</string>
+    <string name="custom_url_scheme">com.capacitorjs.exampleucapp.plugins.geolocation</string>
 </resources>

--- a/packages/example-app-capacitor/android/app/src/test/java/com/capacitorjs/exampleucapp/plugins/geolocation/ExampleUnitTest.java
+++ b/packages/example-app-capacitor/android/app/src/test/java/com/capacitorjs/exampleucapp/plugins/geolocation/ExampleUnitTest.java
@@ -1,4 +1,4 @@
-package com.getcapacitor;
+package com.capacitorjs.exampleucapp.plugins.geolocation;
 
 import static org.junit.Assert.*;
 

--- a/packages/example-app-capacitor/capacitor.config.json
+++ b/packages/example-app-capacitor/capacitor.config.json
@@ -1,5 +1,5 @@
 {
-  "appId": "com.outsystems.exampleucapp.capacitor.plugins.geolocation",
+  "appId": "com.capacitorjs.exampleucapp.plugins.geolocation",
   "appName": "OSGLOC Sample",
   "bundledWebRuntime": false,
   "webDir": "dist",

--- a/packages/example-app-capacitor/ios/App/App.xcodeproj/project.pbxproj
+++ b/packages/example-app-capacitor/ios/App/App.xcodeproj/project.pbxproj
@@ -354,7 +354,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				MARKETING_VERSION = 1.0;
 				OTHER_SWIFT_FLAGS = "$(inherited) \"-D\" \"COCOAPODS\" \"-DDEBUG\"";
-				PRODUCT_BUNDLE_IDENTIFIER = com.outsystems.exampleucapp.capacitor.plugins.geolocation;
+				PRODUCT_BUNDLE_IDENTIFIER = com.capacitorjs.exampleucapp.plugins.geolocation;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
 				SWIFT_VERSION = 5.0;
@@ -373,7 +373,7 @@
 				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.outsystems.exampleucapp.capacitor.plugins.geolocation;
+				PRODUCT_BUNDLE_IDENTIFIER = com.capacitorjs.exampleucapp.plugins.geolocation;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "";
 				SWIFT_VERSION = 5.0;


### PR DESCRIPTION
Following the update of the [Android lib package name](https://github.com/ionic-team/OSGeolocationLib-Android/pull/2) - Update usages of the lib to use `io.ionic.libs.osgeolocationlib`

Also update package names for plugin and sample app to use `com.capacitorjs` instead of `com.outsystems`